### PR TITLE
Inherit from TurboFormMixin in CBVs

### DIFF
--- a/src/turbo_response/views.py
+++ b/src/turbo_response/views.py
@@ -13,7 +13,6 @@ from django.views.generic import (
 from . import Action
 from .mixins import (
     TurboFormMixin,
-    TurboFormModelMixin,
     TurboFrameResponseMixin,
     TurboFrameTemplateResponseMixin,
     TurboStreamFormMixin,
@@ -43,11 +42,11 @@ class TurboFormView(TurboFormMixin, FormView):
     ...
 
 
-class TurboCreateView(TurboFormModelMixin, CreateView):
+class TurboCreateView(TurboFormMixin, CreateView):
     ...
 
 
-class TurboUpdateView(TurboFormModelMixin, UpdateView):
+class TurboUpdateView(TurboFormMixin, UpdateView):
     ...
 
 


### PR DESCRIPTION
Fixes #8 

@danjac The `TurboFormModelMixin` is no longer used anywhere. Potentially worth deleting but it depends if you think people are inheriting from it directly?